### PR TITLE
Fix #9 Update github repository pattern

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -20,7 +20,7 @@ export {
   PLUGIN_PATH
 }
 
-export const REPO_PATTERN = /.*github.com\/([a-z-_]+\/[a-z-_]+)\.git$/i
+export const REPO_PATTERN = /.*github\.com\/([a-z-_]+\/[a-z-_.]+)\.git$/i
 
 export const extractRepoName = (): string => {
   const pkg = readPkg.sync()


### PR DESCRIPTION
Allow repository names containing dots like a user or organisation github pages