### PR TITLE
fix: remove types import for aggregate-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@types/debug": "^4.1.5",
     "@types/git-url-parse": "^9.0.0",
     "@types/semantic-release": "^17.2.0",
-    "@types/aggregate-error": "^1.0.1",
     "@types/gh-pages": "^3.0.0",
     "@types/lodash": "^4.14.168",
     "@qiwi/substrate": "^1.20.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,13 +815,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@types/aggregate-error@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/aggregate-error/-/aggregate-error-1.0.1.tgz#53195d9135de19a4152ff0ceceea4fcf4c65c9b8"
-  integrity sha512-bdQuVBySRal4CAcvD59et6lgiiyHEXcNZvpNDYRB+M/PRsqtnF1iTkG2DEAvlTYHnymwBxOOCN38YGZanmnJ0g==
-  dependencies:
-    aggregate-error "*"
-
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -1127,7 +1120,7 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-aggregate-error@*, aggregate-error@^3.0.0, aggregate-error@^3.1.0:
+aggregate-error@^3.0.0, aggregate-error@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
   integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==


### PR DESCRIPTION
The `@types/aggregate-error` packages brings in `aggregate-error@*`, which breaks for older versions of Node. Now that `aggregate-error` bundles types directly, we no longer have a need for this dependency.