### PR TITLE
feat: support multiple patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
 gh-pages publishing plugin for [semantic-release](https://github.com/semantic-release/semantic-release)
 
-| Step               | Description |
-|--------------------|-------------|
+| Step               | Description                                                                                    |
+|--------------------|------------------------------------------------------------------------------------------------|
 | `verifyConditions` | Verify the presence of the `GH_TOKEN` set via [environment variables](#environment-variables). |
-| `publish`          | Pushes commit to the [documentation branch](#options) |
+| `publish`          | Pushes commit to the [documentation branch](#options)                                          |
 
 ## Install
+
 ```bash
 # yarn
 yarn add @qiwi/semantic-release-gh-pages-plugin --dev
@@ -21,7 +22,10 @@ npm i @qiwi/semantic-release-gh-pages-plugin -D
 ```
 
 ## Usage
-Describe plugin configuration in [package.json / .releaserc.js](https://github.com/semantic-release/semantic-release/blob/master/docs/01-usage/plugins.md#plugins-configuration-options)
+
+Describe plugin configuration
+in [package.json / .releaserc.js](https://github.com/semantic-release/semantic-release/blob/master/docs/01-usage/plugins.md#plugins-configuration-options)
+
 ```json
 {
   "release": {
@@ -46,7 +50,9 @@ Describe plugin configuration in [package.json / .releaserc.js](https://github.c
   }
 }
 ```
+
 or even shorter if default settings are used:
+
 ```json
 {
   "release": {
@@ -64,6 +70,7 @@ or even shorter if default settings are used:
 ```
 
 ## Configuration
+
 ### Environment variables
 
 | Variable                     | Description                                               |
@@ -84,7 +91,8 @@ or even shorter if default settings are used:
 | `pullTagsBranch` | Target branch for tags fetching hook. If '' empty string, skips this action                                                                                 | `globalConfig.branch` \|\| `master`                                                                                                        |
 | `dotfiles`       | gh-pages [dotfiles](https://github.com/tschaub/gh-pages#optionsdotfiles) option                                                                             | `false`                                                                                                                                    |
 | `add`            | gh-pages [add](https://github.com/tschaub/gh-pages#optionsadd) option                                                                                       | `false`                                                                                                                                    |
-| `pattern`        | gh-pages [src](https://github.com/tschaub/gh-pages#optionssrc) option                                                                                       | `**/*`                                                                                                                                     |
+| `pattern`        | gh-pages [src](https://github.com/tschaub/gh-pages#optionssrc) option. Use `:` to separate several values `**/*.md:**/*.png`                                | `**/*`                                                                                                                                     |
 
 ## License
+
 [MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "@qiwi/substrate-types": "^2.1.0",
     "aggregate-error": "^3.1.0",
     "debug": "^4.4.0",
-    "execa": "^5.1.1",
     "gh-pages": "^6.2.0",
     "git-url-parse": "^16.0.0",
     "lodash": "^4.17.21",
     "queuefy": "^1.2.1",
     "read-pkg": "^5.2.0",
     "then-request": "^6.0.2",
-    "tslib": "^2.8.1"
+    "tslib": "^2.8.1",
+    "zurk": "^0.9.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",

--- a/src/main/ts/config.ts
+++ b/src/main/ts/config.ts
@@ -134,7 +134,7 @@ export const resolveConfig = async (pluginConfig: TAnyMap, context: TContext, pa
     msg = DEFAULT_MSG,
     src = DEFAULT_SRC,
     dst = DEFAULT_DST,
-    pattern = DEFAULT_PATTERN,
+    pattern: _pattern = DEFAULT_PATTERN,
     add,
     dotfiles
   } = opts
@@ -144,6 +144,7 @@ export const resolveConfig = async (pluginConfig: TAnyMap, context: TContext, pa
   const docsBranch = branches?.find(([from]: string[]) => from === ciBranch)?.[1] || branch
   const pullTagsBranch = anyDefined(opts.pullTagsBranch, ciBranch, opts._branch, DEFAULT_PULL_TAGS_BRANCH)
   const token = getToken(context.env, repo)
+  const pattern = _pattern.includes(':') ? _pattern.split(':') : _pattern
 
   debug('resolveConfig args:')
   debug('pluginConfig= %j', pluginConfig)

--- a/src/main/ts/ghpages.ts
+++ b/src/main/ts/ghpages.ts
@@ -1,6 +1,6 @@
 /** @module semantic-release-gh-pages-plugin */
 
-import execa from 'execa'
+import { $ } from 'zurk'
 import { clean, publish as ghpagePublish, PublishOptions } from 'gh-pages'
 import { queuefy } from 'queuefy'
 
@@ -21,19 +21,13 @@ export const pullTags = (opts: IPushOpts): Promise<any> => {
 
   const repo = '' + opts.repo
   const pullTagsBranch = '' + opts.pullTagsBranch
-  const execaOpts = {
-    env: opts.env,
-    cwd: opts.cwd
-  }
 
-  return execa('git', [
-    'pull',
-    '--tags',
-    '--force',
-    repo,
-    pullTagsBranch
-  ], execaOpts)
-    .catch(console.log)
+  return $({
+    env: opts.env,
+    cwd: opts.cwd,
+    shell: false
+  })`git pull --tags --force ${repo} ${pullTagsBranch}`
+    .catch(console.error)
 }
 
 /**

--- a/src/main/ts/index.ts
+++ b/src/main/ts/index.ts
@@ -1,7 +1,6 @@
 /** @module semantic-release-gh-pages-plugin */
 
 import AggregateError from 'aggregate-error'
-import fs from 'node:fs'
 import { isEqual } from 'lodash'
 import path from 'node:path'
 
@@ -9,6 +8,7 @@ import { resolveConfig } from './config'
 import { publish as ghpagesPublish } from './ghpages'
 import { IPushOpts,TContext } from './interface'
 import { render } from './tpl'
+import { isDirectory } from './util'
 
 export * from './defaults'
 
@@ -35,7 +35,7 @@ export const verifyConditions = async (pluginConfig: any, context: TContext) => 
     throw new AggregateError(['package.json repository.url does not match github.com pattern'])
   }
 
-  if (!fs.existsSync(src) || !fs.lstatSync(src).isDirectory()) {
+  if (!isDirectory(src)) {
     logger.error('Resolved docs src path=', path.resolve(src))
     throw new AggregateError(['docs source directory does not exist'])
   }

--- a/src/main/ts/util.ts
+++ b/src/main/ts/util.ts
@@ -1,4 +1,5 @@
 import { ICallable } from '@qiwi/substrate-types'
+import fs from 'node:fs'
 
 export const catchToSmth = (fn: ICallable, smth?: any) => {
   return (...args: any[]) => {
@@ -12,3 +13,5 @@ export const catchToSmth = (fn: ICallable, smth?: any) => {
 }
 
 export const anyDefined = (...args: any[]) => args.find(item => item !== undefined)
+
+export const isDirectory = (path: string) => fs.existsSync(path) && fs.lstatSync(path).isDirectory()

--- a/src/test/ts/config.ts
+++ b/src/test/ts/config.ts
@@ -147,6 +147,37 @@ describe('config', () => {
       })
     })
 
+    it('supports multiple pattern definition', async () => {
+      const step = 'publish'
+      const token = 'token'
+      const pluginConfig = {
+        pattern: '**/*.md:**/*.html'
+      }
+      const context = {
+        logger,
+        branch,
+        options: globalConfig,
+        cwd,
+        env: { GITHUB_TOKEN: token }
+      }
+      const config = await resolveConfig(pluginConfig, context, undefined, step)
+
+      expect(config).toEqual({
+        add: undefined,
+        ciBranch: 'master',
+        docsBranch: DEFAULT_BRANCH,
+        dotfiles: undefined,
+        dst: DEFAULT_DST,
+        enterprise: DEFAULT_ENTERPRISE,
+        msg: DEFAULT_MSG,
+        src: DEFAULT_SRC,
+        token,
+        repo: repositoryUrl,
+        pullTagsBranch: DEFAULT_PULL_TAGS_BRANCH,
+        pattern: ['**/*.md', '**/*.html'],
+      })
+    })
+
     it('overrides `docBranch` with `branches` value if defined', async () => {
       const step = 'publish'
       const path = PLUGIN_PATH

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,7 +2029,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-execa@^5.0.0, execa@^5.1.1:
+execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -5066,3 +5066,8 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zurk@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/zurk/-/zurk-0.9.0.tgz#9dbea11ef84a871cfb542ddded8c7d42c8feeaf5"
+  integrity sha512-MfREZRQx5VySt3VtNrfP+UTALaTTIBquhSuJS/RYAs59YkwAicx6QrXyMMpvJu0wQdfWiJJAhAeOw4+OJLZ8ig==


### PR DESCRIPTION
continues #278 

Introduces multiple pattern support via `:`-separated notation: `'**/*.md:**/.*png'`

- [x] New code is covered by tests

FYI, @dvirtz 

